### PR TITLE
use parent process to write db and child to detect deadlock instead o…

### DIFF
--- a/kyototycoon/kttimeddb.cc
+++ b/kyototycoon/kttimeddb.cc
@@ -112,19 +112,16 @@ bool TimedDB::dump_snapshot_atomic(const std::string& dest, kc::Compressor* zcom
     db_.occupy(true, &forker);
     cpid = forker.cpid();
   };
-  if (cpid > 0) {
+  if (cpid == 0) {
+    // if there's a hang while writing the snapshot
+    // (defined as 2.8 hours going by without the file size changing)
+    // then abort with the "hanging" error
     int64_t osiz = 0;
     int32_t cnt = 0;
-    while (true) {
-      cnt++;
-      int32_t status;
-      int32_t rv = wait_impl(cpid, &status, 1);
-      if (rv == 0) return status == 0;
-      if (rv < 0) {
-        kill_impl(cpid, true);
-        wait_impl(cpid, &status, 1);
-        break;
-      }
+    pid_t parent_id = ::getppid();
+    for (int32_t cnt = 0; cnt < 100000; ++cnt) {
+      kc::Thread::sleep(0.1);
+      
       int64_t nsiz = 0;
       kc::File::Status sbuf;
       if (kc::File::status(dest, &sbuf)) nsiz = sbuf.size;
@@ -132,13 +129,11 @@ bool TimedDB::dump_snapshot_atomic(const std::string& dest, kc::Compressor* zcom
         osiz = nsiz;
         cnt = 0;
       }
-      if (cnt >= 10) {
-        db_.set_error(_KCCODELINE_, kc::BasicDB::Error::LOGIC, "hanging");
-        kill_impl(cpid, true);
-        wait_impl(cpid, &status, 0);
-        break;
-      }
     }
+    db_.set_error(_KCCODELINE_, kc::BasicDB::Error::LOGIC, "hanging");
+    kill_impl(parent_id, true);
+    int32_t status;
+    wait_impl(parent_id, &status, 0);
     return false;
   } else if (cpid == 0) {
     nice_impl(1);
@@ -232,7 +227,11 @@ bool TimedDB::dump_snapshot_atomic(const std::string& dest, kc::Compressor* zcom
     if (cpid != 0) db_.set_error(_KCCODELINE_, kc::BasicDB::Error::SYSTEM, file.error());
     return false;
   }
-  if (cpid == 0) exit_impl(0);
+  if (cpid > 0) {
+    kill_impl(cpid, true);
+    int32_t status;
+    wait_impl(cpid, &status, 0);
+  }
   return !err;
 }
 


### PR DESCRIPTION
When trying to run this in cactus, I keep getting [deadlocks](https://github.com/ComparativeGenomicsToolkit/cactus/pull/148#issuecomment-589151694) whenever it tries to write a snapshot.   

The problem seems to be the function `TimedDB::dump_snapshot_atomic` making a fork() (after checking the db type, StashDB in this case is "forkable").  The child process goes on to write the snapshot, and the parent hangs around waiting for it to complete.  If the child crashes or hangs, the parent logs an error and returns false. 

But I think there's a bug somewhere where where the parent *thread* isn't locking everything it needs to, in which case fork's results are undefined.  So when the child goes to lock a mutex it waits forever.  Rather than spend all year looking for the root problem, I'm just flipping the roles here:  Have the *parent* write the db and the *child* hang around waiting for a deadlock.   This seems to fix the issue I'm seeing.  Side effects will be 
* In the event of ktserver crashing during the db-snapshot, the whole process will exit -- whereas before it'd log an error.
* I've boosted up the wait time for deadlocks considerably. 
* There may be some kind of crazy race condition causing an error if the snapshot hangs exactly 2.7ish hours (to the microsecond) after writing successfully.
I think that all this is fine for the purposes of cactus, but will try on a big example before merging this to master here and and cactus. 
    