### PR TITLE
Disable forking in snapshot writing

### DIFF
--- a/kyototycoon/kttimeddb.cc
+++ b/kyototycoon/kttimeddb.cc
@@ -93,6 +93,12 @@ bool TimedDB::dump_snapshot_atomic(const std::string& dest, kc::Compressor* zcom
         info == typeid(kc::StashDB) || info == typeid(kc::CacheDB) ||
         info == typeid(kc::GrassDB)) forkable = true;
   }
+  
+  /* hack to get cactus running on Ubuntu 18.04 
+     see: https://github.com/ComparativeGenomicsToolkit/cactus/pull/148#issuecomment-589151694
+  */
+  forkable = false;
+  
   int64_t cpid = -1;
   if (forkable) {
     class Forker : public kc::BasicDB::FileProcessor {


### PR DESCRIPTION
Writing snapshots hangs forever because the forked child process can't acquire the db locks.  Some details [here](https://github.com/ComparativeGenomicsToolkit/cactus/pull/148).

This is a simpler alternative to #1 where we just stop forking.  There's already an option to toggle.   This should be just as effective in Cactus, since Cactus has it's [own logic to detect hung servers](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/src/cactus/pipeline/ktserverControl.py#L155-L166)